### PR TITLE
Expose host async context hooks for JS jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Available on Windows(32-bit) **without** mingw.
 
 This fork exposes a small `JS_CaptureCallSites(ctx, skip_count)` C API so embedders such as Nodex can capture structured stack frames without parsing formatted `Error.stack` strings. The API returns frame metadata such as function name, filename, line/column, and whether the frame is native; higher-level Node/V8-compatible `CallSite` behavior remains implemented by the embedder.
 
+It also exposes `JS_SetHostAsyncContextHooks(rt, hooks, opaque)`, a generic job-queue hook for capturing an embedder-owned opaque async context when a JS job is queued and entering/leaving/freeing that context when the job runs or is discarded. QuickJS stores only the opaque pointer; embedders implement higher-level semantics such as `AsyncLocalStorage`, `async_hooks`, or policy delegation.
+
 # Usage
 
 Clone the repo:

--- a/quickjs.c
+++ b/quickjs.c
@@ -383,6 +383,9 @@ struct JSRuntime {
     JSHostPromiseRejectionTracker *host_promise_rejection_tracker;
     void *host_promise_rejection_tracker_opaque;
 
+    JSHostAsyncContextHooks host_async_context_hooks;
+    void *host_async_context_opaque;
+
     struct list_head job_list; /* list of JSJobEntry.link */
 
     JSModuleNormalizeFunc *module_normalize_func;
@@ -960,6 +963,11 @@ typedef struct JSJobEntry {
     struct list_head link;
     JSContext *realm;
     JSJobFunc *job_func;
+    JSHostAsyncContext host_async_context;
+    JSHostAsyncContextEnterFunc *host_async_context_enter;
+    JSHostAsyncContextLeaveFunc *host_async_context_leave;
+    JSHostAsyncContextFreeFunc *host_async_context_free;
+    void *host_async_context_opaque;
     int argc;
     JSValue argv[0];
 } JSJobEntry;
@@ -2284,6 +2292,27 @@ int JS_GetStripInfo(JSRuntime *rt)
     return rt->strip_flags;
 }
 
+void JS_SetHostAsyncContextHooks(JSRuntime *rt,
+                                 const JSHostAsyncContextHooks *hooks,
+                                 void *opaque)
+{
+    if (hooks != NULL) {
+        rt->host_async_context_hooks = *hooks;
+    } else {
+        memset(&rt->host_async_context_hooks, 0, sizeof(rt->host_async_context_hooks));
+    }
+    rt->host_async_context_opaque = opaque;
+}
+
+static void js_free_host_async_context(JSRuntime *rt, JSJobEntry *e)
+{
+    JSHostAsyncContextFreeFunc *free_func = e->host_async_context_free;
+    if (free_func != NULL && e->host_async_context != NULL) {
+        free_func(rt, e->host_async_context, e->host_async_context_opaque);
+    }
+    e->host_async_context = NULL;
+}
+
 static int JS_EnqueueJob2(JSContext *ctx, JSJobFunc *job_func,
                           int argc, JSValueConst *argv, BOOL no_exception)
 {
@@ -2299,6 +2328,15 @@ static int JS_EnqueueJob2(JSContext *ctx, JSJobFunc *job_func,
         return -1;
     e->realm = JS_DupContext(ctx);
     e->job_func = job_func;
+    e->host_async_context_enter = rt->host_async_context_hooks.enter;
+    e->host_async_context_leave = rt->host_async_context_hooks.leave;
+    e->host_async_context_free = rt->host_async_context_hooks.free;
+    e->host_async_context_opaque = rt->host_async_context_opaque;
+    if (rt->host_async_context_hooks.capture != NULL) {
+        e->host_async_context = rt->host_async_context_hooks.capture(ctx, rt->host_async_context_opaque);
+    } else {
+        e->host_async_context = NULL;
+    }
     e->argc = argc;
     for(i = 0; i < argc; i++) {
         e->argv[i] = JS_DupValue(ctx, argv[i]);
@@ -2341,7 +2379,13 @@ int JS_ExecutePendingJob(JSRuntime *rt, JSContext **pctx)
     e = list_entry(rt->job_list.next, JSJobEntry, link);
     list_del(&e->link);
     ctx = e->realm;
+    if (e->host_async_context_enter != NULL && e->host_async_context != NULL) {
+        e->host_async_context_enter(ctx, e->host_async_context, e->host_async_context_opaque);
+    }
     res = e->job_func(ctx, e->argc, (JSValueConst *)e->argv);
+    if (e->host_async_context_leave != NULL && e->host_async_context != NULL) {
+        e->host_async_context_leave(ctx, e->host_async_context, e->host_async_context_opaque);
+    }
     for(i = 0; i < e->argc; i++)
         JS_FreeValue(ctx, e->argv[i]);
     if (JS_IsException(res))
@@ -2349,6 +2393,7 @@ int JS_ExecutePendingJob(JSRuntime *rt, JSContext **pctx)
     else
         ret = 1;
     JS_FreeValue(ctx, res);
+    js_free_host_async_context(rt, e);
     js_free(ctx, e);
     if (pctx) {
         if (js_rc(ctx)->ref_count > 1)
@@ -2437,6 +2482,7 @@ void JS_FreeRuntime(JSRuntime *rt)
         JSJobEntry *e = list_entry(el, JSJobEntry, link);
         for(i = 0; i < e->argc; i++)
             JS_FreeValueRT(rt, e->argv[i]);
+        js_free_host_async_context(rt, e);
         JS_FreeContext(e->realm);
         js_free_rt(rt, e);
     }

--- a/quickjs.h
+++ b/quickjs.h
@@ -952,6 +952,29 @@ typedef void JSHostPromiseRejectionTracker(JSContext *ctx, JSValueConst promise,
                                            JS_BOOL is_handled, void *opaque);
 void JS_SetHostPromiseRejectionTracker(JSRuntime *rt, JSHostPromiseRejectionTracker *cb, void *opaque);
 
+/* Embedder-provided async context propagated through the JS job queue. */
+typedef void *JSHostAsyncContext;
+typedef JSHostAsyncContext JSHostAsyncContextCaptureFunc(JSContext *ctx,
+                                                        void *opaque);
+typedef void JSHostAsyncContextEnterFunc(JSContext *ctx,
+                                         JSHostAsyncContext async_context,
+                                         void *opaque);
+typedef void JSHostAsyncContextLeaveFunc(JSContext *ctx,
+                                         JSHostAsyncContext async_context,
+                                         void *opaque);
+typedef void JSHostAsyncContextFreeFunc(JSRuntime *rt,
+                                        JSHostAsyncContext async_context,
+                                        void *opaque);
+typedef struct JSHostAsyncContextHooks {
+    JSHostAsyncContextCaptureFunc *capture;
+    JSHostAsyncContextEnterFunc *enter;
+    JSHostAsyncContextLeaveFunc *leave;
+    JSHostAsyncContextFreeFunc *free;
+} JSHostAsyncContextHooks;
+void JS_SetHostAsyncContextHooks(JSRuntime *rt,
+                                 const JSHostAsyncContextHooks *hooks,
+                                 void *opaque);
+
 /* return != 0 if the JS code needs to be interrupted */
 typedef int JSInterruptHandler(JSRuntime *rt, void *opaque);
 void JS_SetInterruptHandler(JSRuntime *rt, JSInterruptHandler *cb, void *opaque);


### PR DESCRIPTION
## Summary

- add `JS_SetHostAsyncContextHooks(rt, hooks, opaque)` so embedders can attach an opaque host async context to queued JS jobs
- capture the host context when a job is enqueued, enter/leave it around `JS_ExecutePendingJob()`, and free it when the job completes or is discarded during runtime cleanup
- document the new API in the fork README as a generic substrate for embedders implementing `AsyncLocalStorage`, `async_hooks`, or policy delegation

## Design notes

QuickJS only stores an opaque `void *` plus the hook callbacks captured at enqueue time. It does not know about Nodex, `AsyncLocalStorage`, async IDs, or policy tokens.

This keeps the fork patch generic while giving Nodex a Promise/`await` propagation seam:

```text
JS_EnqueueJob()        -> capture host async context
JS_ExecutePendingJob() -> enter -> run job -> leave -> free
JS_FreeRuntime()       -> free pending captured contexts
```

## Local verification

- `git diff --check`
- `cmake -S . -B /tmp/quickjs-host-async-build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/quickjs-host-async-build --target qjs qjsc run-test262`
- compiled and ran a C host-hook test that verifies:
  - Promise job execution sees the context captured at enqueue time
  - leave restores the previous host context
  - completed jobs free captured context exactly once
  - pending jobs free captured context during `JS_FreeRuntime()` cleanup
- ran QuickJS JS smoke tests with the built `qjs`:
  - `tests/test_closure.js`
  - `tests/test_language.js`
  - `tests/test_builtin.js`
  - `tests/test_loop.js`
  - `tests/test_bigint.js`
  - `tests/test_cyclic_import.js`
  - `tests/test_worker.js`
  - `tests/test_std.js`
  - `tests/test_rw_handler.js`
